### PR TITLE
chore: avoid dependency jinja2 version 3.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "deltalake",
     "duckdb",
     "fastapi",
-    "jinja2>=3",
+    "jinja2>=3,!=3.1.5",
     "pandas",
     "pyarrow!=19.0.0",
     "pydantic>=2",

--- a/uv.lock
+++ b/uv.lock
@@ -419,14 +419,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]
@@ -469,7 +469,7 @@ requires-dist = [
     { name = "deltalake" },
     { name = "duckdb" },
     { name = "fastapi" },
-    { name = "jinja2", specifier = ">=3" },
+    { name = "jinja2", specifier = ">=3,!=3.1.5" },
     { name = "pandas" },
     { name = "pyarrow", specifier = "!=19.0.0" },
     { name = "pydantic", specifier = ">=2" },


### PR DESCRIPTION
CVE report from pip-audit:

```
Found 1 known vulnerability in 1 package
Name   Version ID                  Fix Versions
------ ------- ------------------- ------------
jinja2 3.1.5   GHSA-cpwx-vrp4-4pq7 3.1.6
```