### PR TITLE
chore: set absolute screenshots urls in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ $ laketower -c demo/laketower.yml web
 
 #### Screenshots
 
-![Laketower UI - Tables Overview](docs/static/tables_overview.png)
-![Laketower UI - Tables View](docs/static/tables_view.png)
-![Laketower UI - Tables Statistics](docs/static/tables_statistics.png)
-![Laketower UI - Tables History](docs/static/tables_history.png)
-![Laketower UI - Tables Query](docs/static/tables_query.png)
-![Laketower UI - Queries View](docs/static/queries_view.png)
+![Laketower UI - Tables Overview](https://raw.githubusercontent.com/datalpia/laketower/refs/heads/main/docs/static/tables_overview.png)
+![Laketower UI - Tables View](https://raw.githubusercontent.com/datalpia/laketower/refs/heads/main/docs/static/tables_view.png)
+![Laketower UI - Tables Statistics](https://raw.githubusercontent.com/datalpia/laketower/refs/heads/main/docs/static/tables_statistics.png)
+![Laketower UI - Tables History](https://raw.githubusercontent.com/datalpia/laketower/refs/heads/main/docs/static/tables_history.png)
+![Laketower UI - Tables Query](https://raw.githubusercontent.com/datalpia/laketower/refs/heads/main/docs/static/tables_query.png)
+![Laketower UI - Queries View](https://raw.githubusercontent.com/datalpia/laketower/refs/heads/main/docs/static/queries_view.png)
 
 ### CLI
 


### PR DESCRIPTION
This way, the screenshots should be visible even on PyPI project page