### PR TITLE
fix(web): prevent query results table duplicated controls on back/forward navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - web: increase maximum column cardinality to 100 when displaying categorical values in query results table
+- web: prevent query results table duplicated controls on back/forward navigation
 
 ## [0.9.3] - 2026-04-30
 Patch version fixing client-side CSV export of query results to avoid double

--- a/laketower/templates/queries/_results.html
+++ b/laketower/templates/queries/_results.html
@@ -44,13 +44,14 @@
       const columnNames = {{ query_results.column_names | tojson }}
       const columnUniques = {{ query_results.column_uniques | tojson }}
       const tableData = datatables.columnarToArrays({{ query_results.columns | tojson }}, columnNames)
+      let dt = null
       function initDataTable() {
         const columnTypes = datatables.arrowTypesToDataTables(arrowTypes)
         const columns = [
           { data: null, title: '#', render: (d, t, r, meta) => meta.row + 1, orderable: false, searchable: false },
           ...columnNames.map((name, i) => ({ data: i, title: name }))
         ]
-        datatables.createDataTable('#resultsTable', {
+        dt = datatables.createDataTable('#resultsTable', {
           data: tableData,
           columns: columns,
           columnTypes: columnTypes,
@@ -59,8 +60,20 @@
           columnIndexOffset: 1,
           exportFilename: {{ query.name | tojson }},
         })
-
       }
+      // Destroy DataTables before HTMX snapshots the page for back/forward history.
+      // HTMX re-executes inline scripts on restore, so without this the restored
+      // snapshot (which has DataTables-wrapped DOM) gets wrapped again, doubling controls.
+      document.body.addEventListener(
+        'htmx:beforeHistorySave',
+        () => {
+          if (dt) {
+            dt.destroy()
+            dt = null
+          }
+        },
+        { once: true }
+      )
       if (typeof datatables !== 'undefined') {
         initDataTable()
       } else {

--- a/laketower/templates/tables/_results.html
+++ b/laketower/templates/tables/_results.html
@@ -33,10 +33,11 @@
       const columnNames = {{ table_results.column_names | tojson }}
       const columnUniques = {{ table_results.column_uniques | tojson }}
       const tableData = datatables.columnarToArrays({{ table_results.columns | tojson }}, columnNames)
+      let dt = null
       function initDataTable() {
         const columnTypes = datatables.arrowTypesToDataTables(arrowTypes)
         const columns = columnNames.map((name, i) => ({ data: i, title: name }))
-        datatables.createDataTable('#resultsTable', {
+        dt = datatables.createDataTable('#resultsTable', {
           data: tableData,
           columns: columns,
           columnTypes: columnTypes,
@@ -44,8 +45,20 @@
           columnUniques: columnUniques,
           exportFilename: 'query_results',
         })
-
       }
+      // Destroy DataTables before HTMX snapshots the page for back/forward history.
+      // HTMX re-executes inline scripts on restore, so without this the restored
+      // snapshot (which has DataTables-wrapped DOM) gets wrapped again, doubling controls.
+      document.body.addEventListener(
+        'htmx:beforeHistorySave',
+        () => {
+          if (dt) {
+            dt.destroy()
+            dt = null
+          }
+        },
+        { once: true }
+      )
       if (typeof datatables !== 'undefined') {
         initDataTable()
       } else {


### PR DESCRIPTION
Destroy DataTables before HTMX history snapshot to prevent duplicate controls on back/forward navigation.

References:
- https://htmx.org/quirks/#history-can-be-tricky
- https://htmx.org/events/#htmx:beforeHistorySave